### PR TITLE
Added space in between options on command to Start Mininet on VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ To integrate ODL with our standalone app you must enable these features:
 
 Start Mininet on VM with
 
-`sudo mn --topo tree--controller 'remote,ip=127.0.0.1,port=6653' --switch ovsk,protocols=OpenFlow13`
+`sudo mn --topo tree --controller 'remote,ip=127.0.0.1,port=6653' --switch ovsk,protocols=OpenFlow13`
 
 For adding host nodes (simulated end-user devices connected to the switches) into topology, in the mininet console run command `pingall`. Host nodes appear in the network-topology data.
 


### PR DESCRIPTION
Diff On line 119:
sudo mn --topo tree--controller 'remote,ip=127.0.0.1,port=6653' --switch ovsk,protocols=OpenFlow13` => sudo mn --topo tree --controller 'remote,ip=127.0.0.1,port=6653' --switch ovsk,protocols=OpenFlow13`